### PR TITLE
Enable adding transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Open `http://127.0.0.1:5000` in your browser.
 
 After registering or logging in, use the **Add** link to record new transactions.
 Click **All** to see transactions from every user.
+You can edit or delete your entries from the list on the home page.

--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ Open `http://127.0.0.1:5000` in your browser.
 
 After registering or logging in, use the **Add** link to record new transactions.
 Click **All** to see transactions from every user.
+Use **Report** to view a summary of this month's spending by category.
 You can edit or delete your entries from the list on the home page.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Personal Finance Tracker
+
+A minimal web app to track income and expenses. Built with Flask.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Initialize the database:
+   ```bash
+   flask --app backend.app init-db
+   ```
+3. Run the server:
+   ```bash
+   flask --app backend.app run
+   ```
+
+Open `http://127.0.0.1:5000` in your browser.
+
+After registering or logging in, use the **Add** link to record new transactions.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ A minimal web app to track income and expenses. Built with Flask.
 Open `http://127.0.0.1:5000` in your browser.
 
 After registering or logging in, use the **Add** link to record new transactions.
+Click **All** to see transactions from every user.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,13 @@
 from flask import Flask, render_template, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
-from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user
+from flask_login import (
+    LoginManager,
+    UserMixin,
+    login_user,
+    login_required,
+    logout_user,
+    current_user,
+)
 from werkzeug.security import generate_password_hash, check_password_hash
 
 app = Flask(__name__)
@@ -41,6 +48,17 @@ def load_user(user_id):
 def index():
     transactions = Transaction.query.filter_by(user_id=current_user.id).all()
     return render_template('index.html', transactions=transactions)
+
+
+@app.route('/all')
+@login_required
+def all_transactions():
+    transactions = (
+        db.session.query(Transaction, User.username)
+        .join(User, Transaction.user_id == User.id)
+        .all()
+    )
+    return render_template('all_transactions.html', transactions=transactions)
 
 
 @app.route('/add', methods=['GET', 'POST'])

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,97 @@
+from flask import Flask, render_template, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user
+from werkzeug.security import generate_password_hash, check_password_hash
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'change-me'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///finance.db'
+
+
+db = SQLAlchemy(app)
+login_manager = LoginManager()
+login_manager.login_view = 'login'
+login_manager.init_app(app)
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(150), unique=True, nullable=False)
+    password_hash = db.Column(db.String(256), nullable=False)
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
+
+class Transaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    date = db.Column(db.Date, nullable=False)
+    category = db.Column(db.String(100), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    description = db.Column(db.String(255))
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+@app.route('/')
+@login_required
+def index():
+    transactions = Transaction.query.filter_by(user_id=current_user.id).all()
+    return render_template('index.html', transactions=transactions)
+
+
+@app.route('/add', methods=['GET', 'POST'])
+@login_required
+def add_transaction():
+    from flask import request
+    if request.method == 'POST':
+        t = Transaction(
+            user_id=current_user.id,
+            date=request.form['date'],
+            category=request.form['category'],
+            amount=request.form['amount'],
+            description=request.form['description'],
+        )
+        db.session.add(t)
+        db.session.commit()
+        return redirect(url_for('index'))
+    return render_template('add_transaction.html')
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    from flask import request
+    if request.method == 'POST':
+        user = User.query.filter_by(username=request.form['username']).first()
+        if user and user.check_password(request.form['password']):
+            login_user(user)
+            return redirect(url_for('index'))
+    return render_template('login.html')
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('login'))
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    from flask import request
+    if request.method == 'POST':
+        user = User(username=request.form['username'])
+        user.set_password(request.form['password'])
+        db.session.add(user)
+        db.session.commit()
+        login_user(user)
+        return redirect(url_for('index'))
+    return render_template('register.html')
+
+@app.cli.command('init-db')
+def init_db():
+    db.create_all()
+    print('Database initialized')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, redirect, url_for
+from datetime import date
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import (
     LoginManager,
@@ -59,6 +60,19 @@ def all_transactions():
         .all()
     )
     return render_template('all_transactions.html', transactions=transactions)
+
+
+@app.route('/report')
+@login_required
+def monthly_report():
+    start = date.today().replace(day=1)
+    totals = (
+        db.session.query(Transaction.category, db.func.sum(Transaction.amount))
+        .filter(Transaction.user_id == current_user.id, Transaction.date >= start)
+        .group_by(Transaction.category)
+        .all()
+    )
+    return render_template('report.html', totals=totals, start=start)
 
 
 @app.route('/add', methods=['GET', 'POST'])

--- a/backend/app.py
+++ b/backend/app.py
@@ -78,6 +78,33 @@ def add_transaction():
         return redirect(url_for('index'))
     return render_template('add_transaction.html')
 
+
+@app.route('/edit/<int:tx_id>', methods=['GET', 'POST'])
+@login_required
+def edit_transaction(tx_id):
+    from flask import request
+    t = Transaction.query.get_or_404(tx_id)
+    if t.user_id != current_user.id:
+        return redirect(url_for('index'))
+    if request.method == 'POST':
+        t.date = request.form['date']
+        t.category = request.form['category']
+        t.amount = request.form['amount']
+        t.description = request.form['description']
+        db.session.commit()
+        return redirect(url_for('index'))
+    return render_template('edit_transaction.html', transaction=t)
+
+
+@app.route('/delete/<int:tx_id>')
+@login_required
+def delete_transaction(tx_id):
+    t = Transaction.query.get_or_404(tx_id)
+    if t.user_id == current_user.id:
+        db.session.delete(t)
+        db.session.commit()
+    return redirect(url_for('index'))
+
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     from flask import request

--- a/backend/static/style.css
+++ b/backend/static/style.css
@@ -1,0 +1,2 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+nav a { margin-right: 10px; }

--- a/backend/templates/add_transaction.html
+++ b/backend/templates/add_transaction.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Add Transaction</h1>
+<form method="post">
+    <label>Date:</label><br>
+    <input name="date" type="date" required><br>
+    <label>Category:</label><br>
+    <input name="category" required><br>
+    <label>Amount:</label><br>
+    <input name="amount" type="number" step="0.01" required><br>
+    <label>Description:</label><br>
+    <input name="description"><br>
+    <button type="submit">Add</button>
+</form>
+{% endblock %}

--- a/backend/templates/all_transactions.html
+++ b/backend/templates/all_transactions.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>All Transactions</h1>
+<table>
+    <tr><th>User</th><th>Date</th><th>Category</th><th>Amount</th><th>Description</th></tr>
+    {% for t, username in transactions %}
+    <tr>
+        <td>{{ username }}</td>
+        <td>{{ t.date }}</td>
+        <td>{{ t.category }}</td>
+        <td>{{ t.amount }}</td>
+        <td>{{ t.description }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -6,6 +6,7 @@
     {% if current_user.is_authenticated %}
     <a href="{{ url_for('index') }}">Home</a> |
     <a href="{{ url_for('add_transaction') }}">Add</a> |
+    <a href="{{ url_for('all_transactions') }}">All</a> |
     <a href="{{ url_for('logout') }}">Logout</a>
     {% else %}
     <a href="{{ url_for('login') }}">Login</a> |

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -7,6 +7,7 @@
     <a href="{{ url_for('index') }}">Home</a> |
     <a href="{{ url_for('add_transaction') }}">Add</a> |
     <a href="{{ url_for('all_transactions') }}">All</a> |
+    <a href="{{ url_for('monthly_report') }}">Report</a> |
     <a href="{{ url_for('logout') }}">Logout</a>
     {% else %}
     <a href="{{ url_for('login') }}">Login</a> |

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>Finance Tracker</title>
+<link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+<body>
+<nav>
+    {% if current_user.is_authenticated %}
+    <a href="{{ url_for('index') }}">Home</a> |
+    <a href="{{ url_for('add_transaction') }}">Add</a> |
+    <a href="{{ url_for('logout') }}">Logout</a>
+    {% else %}
+    <a href="{{ url_for('login') }}">Login</a> |
+    <a href="{{ url_for('register') }}">Register</a>
+    {% endif %}
+</nav>
+<hr>
+{% block content %}{% endblock %}
+</body>

--- a/backend/templates/edit_transaction.html
+++ b/backend/templates/edit_transaction.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Transaction</h1>
+<form method="post">
+    <label>Date:</label><br>
+    <input name="date" type="date" value="{{ transaction.date }}" required><br>
+    <label>Category:</label><br>
+    <input name="category" value="{{ transaction.category }}" required><br>
+    <label>Amount:</label><br>
+    <input name="amount" type="number" step="0.01" value="{{ transaction.amount }}" required><br>
+    <label>Description:</label><br>
+    <input name="description" value="{{ transaction.description }}"><br>
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Transactions</h1>
+<p><a href="{{ url_for('add_transaction') }}">Add Transaction</a></p>
+<table>
+    <tr><th>Date</th><th>Category</th><th>Amount</th><th>Description</th></tr>
+    {% for t in transactions %}
+    <tr>
+        <td>{{ t.date }}</td>
+        <td>{{ t.category }}</td>
+        <td>{{ t.amount }}</td>
+        <td>{{ t.description }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -3,13 +3,22 @@
 <h1>Transactions</h1>
 <p><a href="{{ url_for('add_transaction') }}">Add Transaction</a></p>
 <table>
-    <tr><th>Date</th><th>Category</th><th>Amount</th><th>Description</th></tr>
+    <tr>
+        <th>Date</th>
+        <th>Category</th>
+        <th>Amount</th>
+        <th>Description</th>
+        <th></th>
+        <th></th>
+    </tr>
     {% for t in transactions %}
     <tr>
         <td>{{ t.date }}</td>
         <td>{{ t.category }}</td>
         <td>{{ t.amount }}</td>
         <td>{{ t.description }}</td>
+        <td><a href="{{ url_for('edit_transaction', tx_id=t.id) }}">Edit</a></td>
+        <td><a href="{{ url_for('delete_transaction', tx_id=t.id) }}">Delete</a></td>
     </tr>
     {% endfor %}
 </table>

--- a/backend/templates/login.html
+++ b/backend/templates/login.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Login</h1>
+<form method="post">
+    <input name="username" placeholder="Username"><br>
+    <input name="password" placeholder="Password" type="password"><br>
+    <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/backend/templates/register.html
+++ b/backend/templates/register.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Register</h1>
+<form method="post">
+    <input name="username" placeholder="Username"><br>
+    <input name="password" placeholder="Password" type="password"><br>
+    <button type="submit">Register</button>
+</form>
+{% endblock %}

--- a/backend/templates/report.html
+++ b/backend/templates/report.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Spending for {{ start.strftime('%B %Y') }}</h1>
+<table>
+    <tr><th>Category</th><th>Total</th></tr>
+    {% for category, total in totals %}
+    <tr>
+        <td>{{ category }}</td>
+        <td>{{ '{:.2f}'.format(total) }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+Flask-SQLAlchemy
+Flask-Login
+Werkzeug


### PR DESCRIPTION
## Summary
- allow adding transactions through `/add`
- link to add page in templates
- document workflow

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6841619e9ddc8328a56a864be4994492